### PR TITLE
[Anon] File update: Tomb Kings - 8thBRB_8thAB.cat

### DIFF
--- a/Tomb Kings - 8thBRB_8thAB.cat
+++ b/Tomb Kings - 8thBRB_8thAB.cat
@@ -1,37 +1,6 @@
-<?xml version="1.0" encoding="UTF-8"?><catalogue xmlns="http://www.battlescribe.net/schema/catalogueSchema" id="a7025b50-d23a-4c71-9277-50d2ddab25d5" revision="3" gameSystemId="be4eb679-97dc-4876-b582-19ff87fae0fd" gameSystemRevision="1" battleScribeVersion="1.15" name="Tomb Kings - Army Book (2013-4) -V8.8.4." authorName="Vincent Goede (StealthKnightSteg)" authorUrl="http://battlescribedata.appspot.com/#/repo/whfb">
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<catalogue id="a7025b50-d23a-4c71-9277-50d2ddab25d5" revision="5" gameSystemId="be4eb679-97dc-4876-b582-19ff87fae0fd" gameSystemRevision="1" battleScribeVersion="1.15" name="Tomb Kings - Army Book - V8.8.5" authorName="Vincent Goede (StealthKnightSteg)" authorUrl="http://battlescribedata.appspot.com/#/repo/whfb" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <entries>
-    <entry id="8f0f8418-93c0-a2eb-99ce-11938750c8d7" name="- Army Size" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="1" maxInRoster="1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BRB" page="135">
-      <entries/>
-      <entryGroups>
-        <entryGroup id="3400b165-b4df-6f54-2904-ffbff3139e3e" name="Army Size" defaultEntryId="199f25ea-f7aa-a9fe-9ab3-cf6e77149e2f" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries>
-            <entry id="199f25ea-f7aa-a9fe-9ab3-cf6e77149e2f" name="Army (0-2999 points)" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
-              <entries/>
-              <entryGroups/>
-              <modifiers/>
-              <rules/>
-              <profiles/>
-              <links/>
-            </entry>
-            <entry id="1e98d6d4-9007-de76-24cb-2b721580d2f0" name="Grand Army (3000+ points)" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
-              <entries/>
-              <entryGroups/>
-              <modifiers/>
-              <rules/>
-              <profiles/>
-              <links/>
-            </entry>
-          </entries>
-          <entryGroups/>
-          <modifiers/>
-          <links/>
-        </entryGroup>
-      </entryGroups>
-      <modifiers/>
-      <rules/>
-      <profiles/>
-      <links/>
-    </entry>
     <entry id="923bfa3d-1c7e-4b2b-98c1-acf53db262e1" name="Arkhan the Black" points="360.0" categoryId="4c6f72647323232344415441232323" type="model" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
       <entries>
         <entry id="2af75bea-5fce-4efc-9034-2213fc3209cd" name="Hierophant" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
@@ -90,7 +59,7 @@
                   <characteristics>
                     <characteristic characteristicId="52616e676523232344415441232323" name="Range" value="Combat"/>
                     <characteristic characteristicId="537472656e67746823232344415441232323" name="Strength" value="As user"/>
-                    <characteristic characteristicId="5370656369616c2052756c657323232344415441232323" name="Special Rules" value="For every unsaved Wound caused by this bade to an enemy in close combat, Arkhan's unit immediatly recovers a Wound for each one inflicted, as described in Resurrecting Fallen Warriors (AB-28)"/>
+                    <characteristic characteristicId="5370656369616c2052756c657323232344415441232323" name="Special Rules" value="For every unsaved Wound caused by this bade to an enemy in close combat, Arkhan&apos;s unit immediatly recovers a Wound for each one inflicted, as described in Resurrecting Fallen Warriors (AB-28)"/>
                   </characteristics>
                   <modifiers/>
                 </profile>
@@ -112,7 +81,7 @@
               <profiles>
                 <profile id="97d672d7-ed93-0154-5cf3-b4138d57b217" profileTypeId="417263616e6520616e6420456e6368616e746564204974656d23232344415441232323" name="Staff of Nagash" hidden="false" book="AB" page="57">
                   <characteristics>
-                    <characteristic characteristicId="4d616769632050726f706572747923232344415441232323" name="Magic Property" value="At the end of the opponent's Magic phase, you can store up to 3 unused dispel dice from your pool in the Staff. At the beginning of your next Magic phase, add these dice to your power dice pool. If Arkhan was removed as casualty the dice are lost."/>
+                    <characteristic characteristicId="4d616769632050726f706572747923232344415441232323" name="Magic Property" value="At the end of the opponent&apos;s Magic phase, you can store up to 3 unused dispel dice from your pool in the Staff. At the beginning of your next Magic phase, add these dice to your power dice pool. If Arkhan was removed as casualty the dice are lost."/>
                   </characteristics>
                   <modifiers/>
                 </profile>
@@ -265,7 +234,7 @@
       <modifiers>
         <modifier type="increment" field="maxInRoster" value="3.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
           <conditions>
-            <condition parentId="roster" childId="1e98d6d4-9007-de76-24cb-2b721580d2f0" field="selections" type="equal to" value="1.0"/>
+            <condition parentId="roster" childId="no child" field="points limit" type="at least" value="3000.0"/>
           </conditions>
           <conditionGroups/>
         </modifier>
@@ -362,22 +331,22 @@
       <modifiers>
         <modifier type="increment" field="maxInRoster" value="2.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
           <conditions>
-            <condition parentId="roster" childId="1e98d6d4-9007-de76-24cb-2b721580d2f0" field="selections" type="equal to" value="1.0"/>
+            <condition parentId="roster" childId="no child" field="points limit" type="at least" value="3000.0"/>
           </conditions>
           <conditionGroups/>
         </modifier>
       </modifiers>
       <rules>
         <rule id="e2f9202a-6fe0-4171-fa41-02071c2d5927" name="Covenant of Power" hidden="false" book="AB" page="40">
-          <description>.</description>
+          <description>Add D3 power dice to your pool at the start of you Magic phase if you have at least one Caske of Souls on the table.</description>
           <modifiers/>
         </rule>
         <rule id="ec22cd39-ca2e-53cb-9d7c-b000ac7d9628" name="Light of Death" hidden="false" book="AB" page="40">
-          <description>.</description>
+          <description>Innate bound spell (power level 5). Can be used as long as the Keeper of the Casket model is alive and the Casket of Souls has not moved this turn. Direct Damage spell with 48&quot; range. Affexted units must take LD test on 3D6. For each point failed, the unit suffers an automatic Wound with no armour saves allowed, distributed as for shooting attacks. Roll a D6, on 3+ continue on an unengaged enemy unit within 6&quot; of the affected unit that has not been targeted by Light of Death in that magic phase. Continue until you roll less than 3 or no more targets are available.</description>
           <modifiers/>
         </rule>
         <rule id="3d2348a6-7b84-bd13-093e-1015bcf04da3" name="Unleashed Souls" hidden="false" book="AB" page="40">
-          <description>.</description>
+          <description>Upon destruction, every unit within 12&quot; receives D6 S6 hits on a 4+ of a D6, distributed as for shooting. These are magical attacks with no armor save allowed.</description>
           <modifiers/>
         </rule>
       </rules>
@@ -544,7 +513,7 @@
       <modifiers>
         <modifier type="increment" field="maxInRoster" value="2.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
           <conditions>
-            <condition parentId="roster" childId="1e98d6d4-9007-de76-24cb-2b721580d2f0" field="selections" type="equal to" value="1.0"/>
+            <condition parentId="roster" childId="no child" field="points limit" type="at least" value="3000.0"/>
           </conditions>
           <conditionGroups/>
         </modifier>
@@ -576,7 +545,7 @@
         </profile>
         <profile id="8781c70a-cdd5-5840-197f-5c0a6e205273" profileTypeId="417263616e6520616e6420456e6368616e746564204974656d23232344415441232323" name="Icon of Ptra" hidden="false" book="AB" page="52">
           <characteristics>
-            <characteristic characteristicId="4d616769632050726f706572747923232344415441232323" name="Magic Property" value="Bound Spell (Power Level 3). Shem's Burning Gaze (BRB-495)"/>
+            <characteristic characteristicId="4d616769632050726f706572747923232344415441232323" name="Magic Property" value="Bound Spell (Power Level 3). Shem&apos;s Burning Gaze (BRB-495)"/>
           </characteristics>
           <modifiers/>
         </profile>
@@ -753,7 +722,7 @@
       <modifiers>
         <modifier type="increment" field="maxInRoster" value="3.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
           <conditions>
-            <condition parentId="roster" childId="1e98d6d4-9007-de76-24cb-2b721580d2f0" field="selections" type="equal to" value="1.0"/>
+            <condition parentId="roster" childId="no child" field="points limit" type="at least" value="3000.0"/>
           </conditions>
           <conditionGroups/>
         </modifier>
@@ -1122,51 +1091,6 @@
     </entry>
     <entry id="b52cb408-4cfe-45b3-9e0d-e3340d2f0082" name="Necrolith Colossus" points="170.0" categoryId="5261726523232344415441232323" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="2" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
       <entries>
-        <entry id="aff6f291-4b58-4087-abb2-98aed895442d" name="Additional Hand Weapon" points="5.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <rules/>
-          <profiles/>
-          <links>
-            <link id="334bb630-e94a-87a9-c421-27367baf17b9" targetId="6cc3e674-3f33-d789-c2aa-0e661ac03695" linkType="profile">
-              <modifiers/>
-            </link>
-          </links>
-        </entry>
-        <entry id="583641dd-744c-447e-880e-ff35069240c0" name="Great Weapon" points="10.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <rules/>
-          <profiles/>
-          <links>
-            <link id="e80e6103-6abc-e843-53d5-4b3821eef901" targetId="3bbe1ff7-1a8a-ed02-af34-3db24165654a" linkType="profile">
-              <modifiers/>
-            </link>
-          </links>
-        </entry>
-        <entry id="f5eea27e-4160-419e-a8f3-ec107bc2e00d" name="Bow of the Desert" points="20.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <rules/>
-          <profiles>
-            <profile id="3bd6fd8b-71a7-5b5d-04ed-5ee1bffb54d3" profileTypeId="576561706f6e23232344415441232323" name="Bow of the Desert" hidden="false" book="AB" page="51">
-              <characteristics>
-                <characteristic characteristicId="52616e676523232344415441232323" name="Range" value="48&quot;"/>
-                <characteristic characteristicId="537472656e67746823232344415441232323" name="Strength" value="6"/>
-                <characteristic characteristicId="5370656369616c2052756c657323232344415441232323" name="Special Rules" value="Multiple Wounds (D3) (BRB-73), No Armour Saves"/>
-              </characteristics>
-              <modifiers/>
-            </profile>
-          </profiles>
-          <links>
-            <link id="81d68166-2542-d50f-d0db-e118754f0392" targetId="5b1990fd-d4ac-fec5-e015-753724d1134c" linkType="rule">
-              <modifiers/>
-            </link>
-          </links>
-        </entry>
         <entry id="ebd4c82f-8e2f-e2ea-2ccb-4e5a54ba9abe" name="Huge Sword" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
           <entries/>
           <entryGroups/>
@@ -1180,11 +1104,64 @@
           </links>
         </entry>
       </entries>
-      <entryGroups/>
+      <entryGroups>
+        <entryGroup id="754d-007f-ef10-fc82" name="Weapon" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+          <entries>
+            <entry id="1eaa-8ae7-ff6b-fc2c" name="Great Weapon" points="10.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+              <entries/>
+              <entryGroups/>
+              <modifiers/>
+              <rules/>
+              <profiles/>
+              <links>
+                <link id="3af9-c7a1-b80d-4bb1" targetId="3bbe1ff7-1a8a-ed02-af34-3db24165654a" linkType="profile">
+                  <modifiers/>
+                </link>
+              </links>
+            </entry>
+            <entry id="3454-1110-6007-35b3" name="Bow of the Desert" points="20.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+              <entries/>
+              <entryGroups/>
+              <modifiers/>
+              <rules/>
+              <profiles>
+                <profile id="9107-d762-4231-2785" profileTypeId="576561706f6e23232344415441232323" name="Bow of the Desert" hidden="false" book="AB" page="51">
+                  <characteristics>
+                    <characteristic characteristicId="52616e676523232344415441232323" name="Range" value="48&quot;"/>
+                    <characteristic characteristicId="537472656e67746823232344415441232323" name="Strength" value="6"/>
+                    <characteristic characteristicId="5370656369616c2052756c657323232344415441232323" name="Special Rules" value="Multiple Wounds (D3), No Armour Saves, Penetrate Ranks on unsaved Wound with -1 S per Rank. Randomize hit on units with less than 5 models per rank."/>
+                  </characteristics>
+                  <modifiers/>
+                </profile>
+              </profiles>
+              <links>
+                <link id="1c4d-2541-cb28-0480" targetId="5b1990fd-d4ac-fec5-e015-753724d1134c" linkType="rule">
+                  <modifiers/>
+                </link>
+              </links>
+            </entry>
+            <entry id="2230-316b-fb00-c510" name="Additional Hand weapon" points="5.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+              <entries/>
+              <entryGroups/>
+              <modifiers/>
+              <rules/>
+              <profiles/>
+              <links>
+                <link id="392f-369b-d5ca-c2fd" targetId="6cc3e674-3f33-d789-c2aa-0e661ac03695" linkType="profile">
+                  <modifiers/>
+                </link>
+              </links>
+            </entry>
+          </entries>
+          <entryGroups/>
+          <modifiers/>
+          <links/>
+        </entryGroup>
+      </entryGroups>
       <modifiers>
         <modifier type="increment" field="maxInRoster" value="2.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
           <conditions>
-            <condition parentId="roster" childId="1e98d6d4-9007-de76-24cb-2b721580d2f0" field="selections" type="equal to" value="1.0"/>
+            <condition parentId="roster" childId="no child" field="points limit" type="at least" value="3000.0"/>
           </conditions>
           <conditionGroups/>
         </modifier>
@@ -1331,7 +1308,7 @@
       <modifiers>
         <modifier type="increment" field="maxInRoster" value="3.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
           <conditions>
-            <condition parentId="roster" childId="1e98d6d4-9007-de76-24cb-2b721580d2f0" field="selections" type="equal to" value="1.0"/>
+            <condition parentId="roster" childId="no child" field="points limit" type="at least" value="3000.0"/>
           </conditions>
           <conditionGroups/>
         </modifier>
@@ -1378,7 +1355,7 @@
       <modifiers>
         <modifier type="increment" field="maxInRoster" value="2.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
           <conditions>
-            <condition parentId="roster" childId="1e98d6d4-9007-de76-24cb-2b721580d2f0" field="selections" type="equal to" value="1.0"/>
+            <condition parentId="roster" childId="no child" field="points limit" type="at least" value="3000.0"/>
           </conditions>
           <conditionGroups/>
         </modifier>
@@ -1670,7 +1647,7 @@
           <modifiers/>
           <rules>
             <rule id="cf0cef47-e83b-ac50-257f-04992f3919b9" name="Skulls of the Foe" hidden="false" book="AB" page="41">
-              <description>.</description>
+              <description>-1 LD on Panik tests as a result of being hit by the Skulls of the Foe.</description>
               <modifiers/>
             </rule>
           </rules>
@@ -1716,14 +1693,14 @@
       <modifiers>
         <modifier type="increment" field="maxInRoster" value="2.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
           <conditions>
-            <condition parentId="roster" childId="1e98d6d4-9007-de76-24cb-2b721580d2f0" field="selections" type="equal to" value="1.0"/>
+            <condition parentId="roster" childId="no child" field="points limit" type="at least" value="3000.0"/>
           </conditions>
           <conditionGroups/>
         </modifier>
       </modifiers>
       <rules>
         <rule id="864736b1-3274-695a-85f4-3eb6bbca9dea" name="Screaming Skulls" hidden="false" book="AB" page="41">
-          <description>.</description>
+          <description>Shooting attacks are magical and have the Flaming Attacks special rule. Units must take Panic test if they suffer one or more casualties.</description>
           <modifiers/>
         </rule>
       </rules>
@@ -1795,7 +1772,7 @@
       <modifiers>
         <modifier type="increment" field="maxInRoster" value="3.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
           <conditions>
-            <condition parentId="roster" childId="1e98d6d4-9007-de76-24cb-2b721580d2f0" field="selections" type="equal to" value="1.0"/>
+            <condition parentId="roster" childId="no child" field="points limit" type="at least" value="3000.0"/>
           </conditions>
           <conditionGroups/>
         </modifier>
@@ -1968,7 +1945,7 @@
           <modifiers/>
           <links/>
         </entryGroup>
-        <entryGroup id="afb2fce0-60a0-8a67-f7d6-e96a191ce4ba" name="Mount" defaultEntryId="491c3094-4958-6b00-68e0-66e47ed51b51" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+        <entryGroup id="afb2fce0-60a0-8a67-f7d6-e96a191ce4ba" name="Mount" defaultEntryId="491c3094-4958-6b00-68e0-66e47ed51b51" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
           <entries>
             <entry id="491c3094-4958-6b00-68e0-66e47ed51b51" name="Chariot of the Gods" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
               <entries>
@@ -2190,84 +2167,64 @@
     <entry id="e5d62fa4-f846-4cac-a6b6-51a0c50427ff" name="Skeleton Chariots" points="0.0" categoryId="436f726523232344415441232323" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
       <entries>
         <entry id="7da8ed0e-62b9-49b8-998b-cdaf639c0128" name="Skeleton Chariots" points="55.0" categoryId="(No Category)" type="model" minSelections="3" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
-          <entries>
-            <entry id="ee4d1648-8e31-716a-0a8f-6df57da22ac7" name="Steeds" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="2" maxSelections="2" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
-              <entries/>
-              <entryGroups/>
-              <modifiers/>
-              <rules/>
-              <profiles/>
-              <links>
-                <link id="c4248187-c4ca-d27c-3905-237009fa4506" targetId="88e99413-5a74-7707-25a2-09f3e8010ede" linkType="profile">
-                  <modifiers/>
-                </link>
-              </links>
-            </entry>
-            <entry id="5cf125b8-9224-daea-b8ac-a21c656870a3" name="Crew" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="2" maxSelections="2" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
-              <entries/>
-              <entryGroups/>
-              <modifiers/>
-              <rules/>
-              <profiles>
-                <profile id="9ce6a86e-18fe-b9fb-1e72-421ed64b91d9" profileTypeId="4d6f64656c23232344415441232323" name="Skeleton Charioteer" hidden="false" book="AB" page="38">
-                  <characteristics>
-                    <characteristic characteristicId="4d23232344415441232323" name="M" value="-"/>
-                    <characteristic characteristicId="575323232344415441232323" name="WS" value="3"/>
-                    <characteristic characteristicId="425323232344415441232323" name="BS" value="2"/>
-                    <characteristic characteristicId="5323232344415441232323" name="S" value="3"/>
-                    <characteristic characteristicId="5423232344415441232323" name="T" value="-"/>
-                    <characteristic characteristicId="5723232344415441232323" name="W" value="-"/>
-                    <characteristic characteristicId="4923232344415441232323" name="I" value="2"/>
-                    <characteristic characteristicId="4123232344415441232323" name="A" value="2"/>
-                    <characteristic characteristicId="4c4423232344415441232323" name="LD" value="7"/>
-                    <characteristic characteristicId="41726d6f75725361766523232344415441232323" name="ArmourSave"/>
-                    <characteristic characteristicId="576172645361766523232344415441232323" name="WardSave"/>
-                    <characteristic characteristicId="4d5223232344415441232323" name="MR"/>
-                    <characteristic characteristicId="5479706523232344415441232323" name="Type" value="-"/>
-                  </characteristics>
-                  <modifiers/>
-                </profile>
-              </profiles>
-              <links>
-                <link id="5760bffb-fcee-cbac-ee1f-bae78ecc5a2d" targetId="92b19831-ae1f-0325-e8b4-4e9a109cb885" linkType="profile">
-                  <modifiers/>
-                </link>
-                <link id="91dc4e81-6178-8c69-d617-333ebc7a0acc" targetId="5b1990fd-d4ac-fec5-e015-753724d1134c" linkType="rule">
-                  <modifiers/>
-                </link>
-                <link id="ae826d90-4c08-c756-5ba9-228c6c0e932e" targetId="e5ebff3b-1f6c-20b5-4654-a3549f8b706b" linkType="profile">
-                  <modifiers/>
-                </link>
-                <link id="4b311c06-5bfd-e0c1-a7c8-0b27d81536d7" targetId="67d13993-131b-545f-1e37-805f7f2a8915" linkType="profile">
-                  <modifiers/>
-                </link>
-              </links>
-            </entry>
-          </entries>
+          <entries/>
+          <entryGroups/>
+          <modifiers/>
+          <rules/>
+          <profiles/>
+          <links/>
+        </entry>
+        <entry id="b24a-d40a-0303-20a9" name="Crew each" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="2" maxSelections="2" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+          <entries/>
           <entryGroups/>
           <modifiers/>
           <rules/>
           <profiles>
-            <profile id="7c2a2dc1-ae44-58db-ff82-ab05f4d082e6" profileTypeId="4d6f64656c23232344415441232323" name="Skeleton Chariot" hidden="false" book="AB" page="38">
+            <profile id="1899-b15e-03c9-df7d" profileTypeId="4d6f64656c23232344415441232323" name="Skeleton Charioteer" hidden="false" book="AB" page="38">
               <characteristics>
                 <characteristic characteristicId="4d23232344415441232323" name="M" value="-"/>
-                <characteristic characteristicId="575323232344415441232323" name="WS" value="-"/>
-                <characteristic characteristicId="425323232344415441232323" name="BS" value="-"/>
-                <characteristic characteristicId="5323232344415441232323" name="S" value="4"/>
-                <characteristic characteristicId="5423232344415441232323" name="T" value="4"/>
-                <characteristic characteristicId="5723232344415441232323" name="W" value="3"/>
-                <characteristic characteristicId="4923232344415441232323" name="I" value="-"/>
-                <characteristic characteristicId="4123232344415441232323" name="A" value="-"/>
-                <characteristic characteristicId="4c4423232344415441232323" name="LD" value="-"/>
-                <characteristic characteristicId="41726d6f75725361766523232344415441232323" name="ArmourSave" value="5+"/>
+                <characteristic characteristicId="575323232344415441232323" name="WS" value="3"/>
+                <characteristic characteristicId="425323232344415441232323" name="BS" value="2"/>
+                <characteristic characteristicId="5323232344415441232323" name="S" value="3"/>
+                <characteristic characteristicId="5423232344415441232323" name="T" value="-"/>
+                <characteristic characteristicId="5723232344415441232323" name="W" value="-"/>
+                <characteristic characteristicId="4923232344415441232323" name="I" value="2"/>
+                <characteristic characteristicId="4123232344415441232323" name="A" value="2"/>
+                <characteristic characteristicId="4c4423232344415441232323" name="LD" value="7"/>
+                <characteristic characteristicId="41726d6f75725361766523232344415441232323" name="ArmourSave"/>
                 <characteristic characteristicId="576172645361766523232344415441232323" name="WardSave"/>
                 <characteristic characteristicId="4d5223232344415441232323" name="MR"/>
-                <characteristic characteristicId="5479706523232344415441232323" name="Type" value="Chariot"/>
+                <characteristic characteristicId="5479706523232344415441232323" name="Type" value="-"/>
               </characteristics>
               <modifiers/>
             </profile>
           </profiles>
-          <links/>
+          <links>
+            <link id="4a3e-af59-4931-e484" targetId="92b19831-ae1f-0325-e8b4-4e9a109cb885" linkType="profile">
+              <modifiers/>
+            </link>
+            <link id="26cd-47a6-77d8-8ce5" targetId="5b1990fd-d4ac-fec5-e015-753724d1134c" linkType="rule">
+              <modifiers/>
+            </link>
+            <link id="489f-7984-5ae8-a9a3" targetId="e5ebff3b-1f6c-20b5-4654-a3549f8b706b" linkType="profile">
+              <modifiers/>
+            </link>
+            <link id="5d57-f677-e42b-ef89" targetId="67d13993-131b-545f-1e37-805f7f2a8915" linkType="profile">
+              <modifiers/>
+            </link>
+          </links>
+        </entry>
+        <entry id="828c-dc8f-179d-7512" name="Steeds each" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="2" maxSelections="2" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+          <entries/>
+          <entryGroups/>
+          <modifiers/>
+          <rules/>
+          <profiles/>
+          <links>
+            <link id="654c-700f-36e9-81a0" targetId="88e99413-5a74-7707-25a2-09f3e8010ede" linkType="profile">
+              <modifiers/>
+            </link>
+          </links>
         </entry>
       </entries>
       <entryGroups>
@@ -2335,7 +2292,26 @@
       </entryGroups>
       <modifiers/>
       <rules/>
-      <profiles/>
+      <profiles>
+        <profile id="96a4-1fca-d609-f58b" profileTypeId="4d6f64656c23232344415441232323" name="Skeleton Chariot" hidden="false" book="AB" page="38">
+          <characteristics>
+            <characteristic characteristicId="4d23232344415441232323" name="M" value="-"/>
+            <characteristic characteristicId="575323232344415441232323" name="WS" value="-"/>
+            <characteristic characteristicId="425323232344415441232323" name="BS" value="-"/>
+            <characteristic characteristicId="5323232344415441232323" name="S" value="4"/>
+            <characteristic characteristicId="5423232344415441232323" name="T" value="4"/>
+            <characteristic characteristicId="5723232344415441232323" name="W" value="3"/>
+            <characteristic characteristicId="4923232344415441232323" name="I" value="-"/>
+            <characteristic characteristicId="4123232344415441232323" name="A" value="-"/>
+            <characteristic characteristicId="4c4423232344415441232323" name="LD" value="-"/>
+            <characteristic characteristicId="41726d6f75725361766523232344415441232323" name="ArmourSave" value="5+"/>
+            <characteristic characteristicId="576172645361766523232344415441232323" name="WardSave"/>
+            <characteristic characteristicId="4d5223232344415441232323" name="MR"/>
+            <characteristic characteristicId="5479706523232344415441232323" name="Type" value="Chariot"/>
+          </characteristics>
+          <modifiers/>
+        </profile>
+      </profiles>
       <links>
         <link id="79b1fbdb-7d9a-00bf-cbba-e093d269f43f" targetId="4f17b550-4924-0528-3124-3ccb504442d3" linkType="rule">
           <modifiers/>
@@ -2769,7 +2745,7 @@
           <description>.</description>
           <modifiers/>
         </rule>
-        <rule id="6ca5a4c8-8daa-dcf7-7137-95c01fe17646" name="Settra's Champion" hidden="false" book="AB" page="54">
+        <rule id="6ca5a4c8-8daa-dcf7-7137-95c01fe17646" name="Settra&apos;s Champion" hidden="false" book="AB" page="54">
           <description>.</description>
           <modifiers/>
         </rule>
@@ -2921,7 +2897,7 @@
       <modifiers>
         <modifier type="increment" field="maxInRoster" value="3.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
           <conditions>
-            <condition parentId="roster" childId="1e98d6d4-9007-de76-24cb-2b721580d2f0" field="selections" type="equal to" value="1.0"/>
+            <condition parentId="roster" childId="no child" field="points limit" type="at least" value="3000.0"/>
           </conditions>
           <conditionGroups/>
         </modifier>
@@ -2965,7 +2941,7 @@
           <modifiers/>
           <rules>
             <rule id="1a9a9bc3-e416-31fc-1cfa-87b687b6299b" name="Tomb Kings Battle Standard Bearer" hidden="false" book="AB" page="28">
-              <description>.</description>
+              <description>In addition to normal rules, units of Nehekharan Undead within 12&quot; suffer one less Wound due to Unstable or the Hierophant&apos;s death.</description>
               <modifiers/>
             </rule>
           </rules>
@@ -3490,7 +3466,7 @@
       <modifiers>
         <modifier type="increment" field="maxInRoster" value="3.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
           <conditions>
-            <condition parentId="roster" childId="1e98d6d4-9007-de76-24cb-2b721580d2f0" field="selections" type="equal to" value="1.0"/>
+            <condition parentId="roster" childId="no child" field="points limit" type="at least" value="3000.0"/>
           </conditions>
           <conditionGroups/>
         </modifier>
@@ -3577,7 +3553,7 @@
       <modifiers>
         <modifier type="increment" field="maxInRoster" value="3.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
           <conditions>
-            <condition parentId="roster" childId="1e98d6d4-9007-de76-24cb-2b721580d2f0" field="selections" type="equal to" value="1.0"/>
+            <condition parentId="roster" childId="no child" field="points limit" type="at least" value="3000.0"/>
           </conditions>
           <conditionGroups/>
         </modifier>
@@ -3737,7 +3713,7 @@
       <modifiers>
         <modifier type="increment" field="maxInRoster" value="3.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
           <conditions>
-            <condition parentId="roster" childId="1e98d6d4-9007-de76-24cb-2b721580d2f0" field="selections" type="equal to" value="1.0"/>
+            <condition parentId="roster" childId="no child" field="points limit" type="at least" value="3000.0"/>
           </conditions>
           <conditionGroups/>
         </modifier>
@@ -4049,15 +4025,15 @@
           </profiles>
           <links/>
         </entry>
-        <entry id="14596efb-20af-ffa8-6911-5e3d1192b6e5" name="BRB - Trickster's Shard" points="25.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+        <entry id="14596efb-20af-ffa8-6911-5e3d1192b6e5" name="BRB - Trickster&apos;s Shard" points="25.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
           <entries/>
           <entryGroups/>
           <modifiers/>
           <rules/>
           <profiles>
-            <profile id="89f5b87e-3c59-8cca-07db-ed613b5617cf" profileTypeId="417263616e6520616e6420456e6368616e746564204974656d23232344415441232323" name="Trickster's Shard" hidden="false" book="BRB" page="504">
+            <profile id="89f5b87e-3c59-8cca-07db-ed613b5617cf" profileTypeId="417263616e6520616e6420456e6368616e746564204974656d23232344415441232323" name="Trickster&apos;s Shard" hidden="false" book="BRB" page="504">
               <characteristics>
-                <characteristic characteristicId="4d616769632050726f706572747923232344415441232323" name="Magic Property" value="One use only. Declare use at start of your magic phase. If bearer's spell is dispelled the enemy wizard suffers a wound (no armour save) on a 5+."/>
+                <characteristic characteristicId="4d616769632050726f706572747923232344415441232323" name="Magic Property" value="One use only. Declare use at start of your magic phase. If bearer&apos;s spell is dispelled the enemy wizard suffers a wound (no armour save) on a 5+."/>
               </characteristics>
               <modifiers/>
             </profile>
@@ -4109,13 +4085,13 @@
           </profiles>
           <links/>
         </entry>
-        <entry id="d97eaa9e-1c71-c77c-d62c-0f9310bd9ded" name="BRB - Sivejir's Hex Scroll" points="50.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+        <entry id="d97eaa9e-1c71-c77c-d62c-0f9310bd9ded" name="BRB - Sivejir&apos;s Hex Scroll" points="50.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
           <entries/>
           <entryGroups/>
           <modifiers/>
           <rules/>
           <profiles>
-            <profile id="6fa7e930-57c3-28d2-bca4-86e4bca6b42b" profileTypeId="417263616e6520616e6420456e6368616e746564204974656d23232344415441232323" name="Sivejir's Hex Scroll" hidden="false" book="BRB" page="504">
+            <profile id="6fa7e930-57c3-28d2-bca4-86e4bca6b42b" profileTypeId="417263616e6520616e6420456e6368616e746564204974656d23232344415441232323" name="Sivejir&apos;s Hex Scroll" hidden="false" book="BRB" page="504">
               <characteristics>
                 <characteristic characteristicId="4d616769632050726f706572747923232344415441232323" name="Magic Property" value="One use only. Instead of dispel. Enemy wizard rolls D6 if higher then his wizard level he transforms in a toad. No channel, no casting, no items work, stats reduced to 1 (except W). Controlling player rolls D6 at start of each magic phase, on a 4+ transformation ends."/>
               </characteristics>
@@ -4175,7 +4151,7 @@
           <modifiers/>
           <rules/>
           <profiles>
-            <profile id="cad63cbf-f172-d839-20f9-b1d276e0e3b7" profileTypeId="417263616e6520616e6420456e6368616e746564204974656d23232344415441232323" name="Staff of Sorcery (FAQ'ed)" hidden="false" book="BRB" page="504">
+            <profile id="cad63cbf-f172-d839-20f9-b1d276e0e3b7" profileTypeId="417263616e6520616e6420456e6368616e746564204974656d23232344415441232323" name="Staff of Sorcery (FAQ&apos;ed)" hidden="false" book="BRB" page="504">
               <characteristics>
                 <characteristic characteristicId="4d616769632050726f706572747923232344415441232323" name="Magic Property" value="+1 bonus on attempts to dispel"/>
               </characteristics>
@@ -4184,28 +4160,28 @@
           </profiles>
           <links/>
         </entry>
-        <entry id="85d90552-e806-5777-2777-b4806c6a95e9" name="AB - Enkhil's Kanopi" points="25.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+        <entry id="85d90552-e806-5777-2777-b4806c6a95e9" name="AB - Enkhil&apos;s Kanopi" points="25.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
           <entries/>
           <entryGroups/>
           <modifiers/>
           <rules/>
           <profiles>
-            <profile id="5701f73f-ddef-4c61-c21d-b241e2e14003" profileTypeId="417263616e6520616e6420456e6368616e746564204974656d23232344415441232323" name="Enkhil's Kanopi" hidden="false" book="AB" page="63">
+            <profile id="5701f73f-ddef-4c61-c21d-b241e2e14003" profileTypeId="417263616e6520616e6420456e6368616e746564204974656d23232344415441232323" name="Enkhil&apos;s Kanopi" hidden="false" book="AB" page="63">
               <characteristics>
-                <characteristic characteristicId="4d616769632050726f706572747923232344415441232323" name="Magic Property" value="Bound Spell (Power Level 3). roll a D6 for every 'remains in play' spell on the tabletop: on a 2+ that spell is automatically dispelled. For each spell ended this way add D3 power dice."/>
+                <characteristic characteristicId="4d616769632050726f706572747923232344415441232323" name="Magic Property" value="Bound Spell (Power Level 3). roll a D6 for every &apos;remains in play&apos; spell on the tabletop: on a 2+ that spell is automatically dispelled. For each spell ended this way add D3 power dice."/>
               </characteristics>
               <modifiers/>
             </profile>
           </profiles>
           <links/>
         </entry>
-        <entry id="b8f43c99-df76-6f30-3912-aaad02de3260" name="AB - Neferra's Scrolls of Mighty Incantations" points="50.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+        <entry id="b8f43c99-df76-6f30-3912-aaad02de3260" name="AB - Neferra&apos;s Scrolls of Mighty Incantations" points="50.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
           <entries/>
           <entryGroups/>
           <modifiers/>
           <rules/>
           <profiles>
-            <profile id="65ae864f-8f0e-5355-d8bd-d7fe3b28a292" profileTypeId="417263616e6520616e6420456e6368616e746564204974656d23232344415441232323" name="Neferra's Scrolls of Mighty Incantations" hidden="false" book="AB" page="63">
+            <profile id="65ae864f-8f0e-5355-d8bd-d7fe3b28a292" profileTypeId="417263616e6520616e6420456e6368616e746564204974656d23232344415441232323" name="Neferra&apos;s Scrolls of Mighty Incantations" hidden="false" book="AB" page="63">
               <characteristics>
                 <characteristic characteristicId="4d616769632050726f706572747923232344415441232323" name="Magic Property" value="One use only. Declare use before casting a spell. If so add bonus dice equal to the wizard level to the power dice used to roll for the spell. Must use atleast 1 dice from the power pool."/>
               </characteristics>
@@ -4229,7 +4205,7 @@
           <profiles>
             <profile id="a2c6a6b1-cda9-464c-7d39-cdf414966b61" profileTypeId="417263616e6520616e6420456e6368616e746564204974656d23232344415441232323" name="Potion of Speed" hidden="false" book="BRB" page="505">
               <characteristics>
-                <characteristic characteristicId="4d616769632050726f706572747923232344415441232323" name="Magic Property" value="One use only. Drink at start of any player's turn. +3 I until end of turn"/>
+                <characteristic characteristicId="4d616769632050726f706572747923232344415441232323" name="Magic Property" value="One use only. Drink at start of any player&apos;s turn. +3 I until end of turn"/>
               </characteristics>
               <modifiers/>
             </profile>
@@ -4244,7 +4220,7 @@
           <profiles>
             <profile id="3799bc4b-a361-1407-7a12-3873fa17fb92" profileTypeId="417263616e6520616e6420456e6368616e746564204974656d23232344415441232323" name="Potion of Foolhardiness" hidden="false" book="BRB" page="505">
               <characteristics>
-                <characteristic characteristicId="4d616769632050726f706572747923232344415441232323" name="Magic Property" value="One use only. Drink at start of any player's turn. Gain Immune to Psychology(BRB-71) and Devastating Charge(BRB-68) until end of turn."/>
+                <characteristic characteristicId="4d616769632050726f706572747923232344415441232323" name="Magic Property" value="One use only. Drink at start of any player&apos;s turn. Gain Immune to Psychology(BRB-71) and Devastating Charge(BRB-68) until end of turn."/>
               </characteristics>
               <modifiers/>
             </profile>
@@ -4266,13 +4242,13 @@
           </profiles>
           <links/>
         </entry>
-        <entry id="bbb7a86f-b05f-e212-4325-80ff37e27469" name="BRB - The Other Trickster's Shard" points="15.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+        <entry id="bbb7a86f-b05f-e212-4325-80ff37e27469" name="BRB - The Other Trickster&apos;s Shard" points="15.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
           <entries/>
           <entryGroups/>
           <modifiers/>
           <rules/>
           <profiles>
-            <profile id="626153e2-ccef-09bb-e3f6-da5820b5bc93" profileTypeId="417263616e6520616e6420456e6368616e746564204974656d23232344415441232323" name="The Other Trickster's Shard" hidden="false" book="BRB" page="505">
+            <profile id="626153e2-ccef-09bb-e3f6-da5820b5bc93" profileTypeId="417263616e6520616e6420456e6368616e746564204974656d23232344415441232323" name="The Other Trickster&apos;s Shard" hidden="false" book="BRB" page="505">
               <characteristics>
                 <characteristic characteristicId="4d616769632050726f706572747923232344415441232323" name="Magic Property" value="Models in base contact (friends and foes) must re-roll successful Ward Saves."/>
               </characteristics>
@@ -4289,7 +4265,7 @@
           <profiles>
             <profile id="36ca8d97-c185-0dc9-74fd-21ae83edb6da" profileTypeId="417263616e6520616e6420456e6368616e746564204974656d23232344415441232323" name="Potion of Toughness" hidden="false" book="BRB" page="505">
               <characteristics>
-                <characteristic characteristicId="4d616769632050726f706572747923232344415441232323" name="Magic Property" value="One use only. Drink at the start of any player's turn. +3 T until end of turn."/>
+                <characteristic characteristicId="4d616769632050726f706572747923232344415441232323" name="Magic Property" value="One use only. Drink at the start of any player&apos;s turn. +3 T until end of turn."/>
               </characteristics>
               <modifiers/>
             </profile>
@@ -4304,7 +4280,7 @@
           <profiles>
             <profile id="1b0c15e5-645b-4a06-cb38-43b0a6c89cf8" profileTypeId="417263616e6520616e6420456e6368616e746564204974656d23232344415441232323" name="Potion of Strength" hidden="false" book="BRB" page="505">
               <characteristics>
-                <characteristic characteristicId="4d616769632050726f706572747923232344415441232323" name="Magic Property" value="One use only. Drink at the start of any player's turn. +3 S until end of turn."/>
+                <characteristic characteristicId="4d616769632050726f706572747923232344415441232323" name="Magic Property" value="One use only. Drink at the start of any player&apos;s turn. +3 S until end of turn."/>
               </characteristics>
               <modifiers/>
             </profile>
@@ -4364,7 +4340,7 @@
           <profiles>
             <profile id="0c81439c-27df-cfeb-a8e4-eb4daf4712bb" profileTypeId="417263616e6520616e6420456e6368616e746564204974656d23232344415441232323" name="Healing Potion" hidden="false" book="BRB" page="505">
               <characteristics>
-                <characteristic characteristicId="4d616769632050726f706572747923232344415441232323" name="Magic Property" value="One use only at start of controlling player's turn. Recover D6 Wounds."/>
+                <characteristic characteristicId="4d616769632050726f706572747923232344415441232323" name="Magic Property" value="One use only at start of controlling player&apos;s turn. Recover D6 Wounds."/>
               </characteristics>
               <modifiers/>
             </profile>
@@ -4401,13 +4377,13 @@
           </profiles>
           <links/>
         </entry>
-        <entry id="9562b101-4085-be6c-b036-d4cc37ba4c2c" name="BRB - Fozzirik's Folding Fortress" points="100.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+        <entry id="9562b101-4085-be6c-b036-d4cc37ba4c2c" name="BRB - Fozzirik&apos;s Folding Fortress" points="100.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
           <entries/>
           <entryGroups/>
           <modifiers/>
           <rules/>
           <profiles>
-            <profile id="df982b27-7b67-175c-18dd-0f19bebbe039" profileTypeId="417263616e6520616e6420456e6368616e746564204974656d23232344415441232323" name="Fozzirik's Folding Fortress" hidden="false" book="BRB" page="505">
+            <profile id="df982b27-7b67-175c-18dd-0f19bebbe039" profileTypeId="417263616e6520616e6420456e6368616e746564204974656d23232344415441232323" name="Fozzirik&apos;s Folding Fortress" hidden="false" book="BRB" page="505">
               <characteristics>
                 <characteristic characteristicId="4d616769632050726f706572747923232344415441232323" name="Magic Property" value="place a Watchtower Building in your deployment zone before army deployment."/>
               </characteristics>
@@ -4454,7 +4430,7 @@
           <profiles>
             <profile id="7e3f760f-0ff1-a965-1f46-a332b624e05f" profileTypeId="417263616e6520616e6420456e6368616e746564204974656d23232344415441232323" name="Golden Death Mask of Kharnut" hidden="false" book="AB" page="62">
               <characteristics>
-                <characteristic characteristicId="4d616769632050726f706572747923232344415441232323" name="Magic Property" value="Terror (BRB-78), Enemy units within 6&quot; cannot use General's Inspiring Presence nor Battle Standard Bearer's Hold Your Ground rule."/>
+                <characteristic characteristicId="4d616769632050726f706572747923232344415441232323" name="Magic Property" value="Terror (BRB-78), Enemy units within 6&quot; cannot use General&apos;s Inspiring Presence nor Battle Standard Bearer&apos;s Hold Your Ground rule."/>
               </characteristics>
               <modifiers/>
             </profile>
@@ -4516,13 +4492,13 @@
           </profiles>
           <links/>
         </entry>
-        <entry id="b88f5fc5-437a-19fc-eee5-c7be6b06e2e1" name="BRB - Gambler's Armour" points="20.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+        <entry id="b88f5fc5-437a-19fc-eee5-c7be6b06e2e1" name="BRB - Gambler&apos;s Armour" points="20.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
           <entries/>
           <entryGroups/>
           <modifiers/>
           <rules/>
           <profiles>
-            <profile id="2c0e8afb-86a7-cc2f-112d-b7765d160217" profileTypeId="41726d6f757223232344415441232323" name="Gambler's Armour" hidden="false" book="BRB" page="502">
+            <profile id="2c0e8afb-86a7-cc2f-112d-b7765d160217" profileTypeId="41726d6f757223232344415441232323" name="Gambler&apos;s Armour" hidden="false" book="BRB" page="502">
               <characteristics>
                 <characteristic characteristicId="536176696e67205468726f77206d6f64696669657223232344415441232323" name="Saving Throw modifier" value="5+"/>
                 <characteristic characteristicId="5370656369616c2052756c657323232344415441232323" name="Special Rules" value="Grants the wearer 6+ WardSave"/>
@@ -4628,16 +4604,16 @@
           </profiles>
           <links/>
         </entry>
-        <entry id="bf79882c-2868-d92c-e481-2b2453ce0f47" name="BRB - Trickster's Helm" points="50.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+        <entry id="bf79882c-2868-d92c-e481-2b2453ce0f47" name="BRB - Trickster&apos;s Helm" points="50.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
           <entries/>
           <entryGroups/>
           <modifiers/>
           <rules/>
           <profiles>
-            <profile id="3d970df9-4eb0-ff13-ef79-9644dd838fbb" profileTypeId="41726d6f757223232344415441232323" name="Trickster's Helm" hidden="false" book="BRB" page="502">
+            <profile id="3d970df9-4eb0-ff13-ef79-9644dd838fbb" profileTypeId="41726d6f757223232344415441232323" name="Trickster&apos;s Helm" hidden="false" book="BRB" page="502">
               <characteristics>
                 <characteristic characteristicId="536176696e67205468726f77206d6f64696669657223232344415441232323" name="Saving Throw modifier" value="-1"/>
-                <characteristic characteristicId="5370656369616c2052756c657323232344415441232323" name="Special Rules" value="Any succesfull roll to wound made against the wearer of the Trickster's Helm must be re-rolled."/>
+                <characteristic characteristicId="5370656369616c2052756c657323232344415441232323" name="Special Rules" value="Any succesfull roll to wound made against the wearer of the Trickster&apos;s Helm must be re-rolled."/>
               </characteristics>
               <modifiers/>
             </profile>
@@ -4705,7 +4681,7 @@
           <profiles>
             <profile id="042d9155-1c0f-6228-51ef-424c91818a11" profileTypeId="4d61676963205374616e6461726423232344415441232323" name="Gleaming Pennant" hidden="false" book="BRB" page="503">
               <characteristics>
-                <characteristic characteristicId="4d61676963616c20456d696e6174696f6e23232344415441232323" name="Magical Emination" value="One use only. Can re-roll it's first failed Ld test."/>
+                <characteristic characteristicId="4d61676963616c20456d696e6174696f6e23232344415441232323" name="Magical Emination" value="One use only. Can re-roll it&apos;s first failed Ld test."/>
               </characteristics>
               <modifiers/>
             </profile>
@@ -4787,13 +4763,13 @@
           </profiles>
           <links/>
         </entry>
-        <entry id="9e0c62d4-e759-302a-9c77-637a56290916" name="BRB - Ranger's Standard" points="50.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+        <entry id="9e0c62d4-e759-302a-9c77-637a56290916" name="BRB - Ranger&apos;s Standard" points="50.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
           <entries/>
           <entryGroups/>
           <modifiers/>
           <rules/>
           <profiles>
-            <profile id="1038e88a-7cd2-22e3-8faa-fd2748917f81" profileTypeId="4d61676963205374616e6461726423232344415441232323" name="Ranger's Standard" hidden="false" book="BRB" page="503">
+            <profile id="1038e88a-7cd2-22e3-8faa-fd2748917f81" profileTypeId="4d61676963205374616e6461726423232344415441232323" name="Ranger&apos;s Standard" hidden="false" book="BRB" page="503">
               <characteristics>
                 <characteristic characteristicId="4d61676963616c20456d696e6174696f6e23232344415441232323" name="Magical Emination" value="Strider (BRB-76)"/>
               </characteristics>
@@ -4817,13 +4793,13 @@
           </profiles>
           <links/>
         </entry>
-        <entry id="d665f1ed-466f-df6f-4ccc-61ca401e11d2" name="BRB - Rampager's Standard" points="55.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+        <entry id="d665f1ed-466f-df6f-4ccc-61ca401e11d2" name="BRB - Rampager&apos;s Standard" points="55.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
           <entries/>
           <entryGroups/>
           <modifiers/>
           <rules/>
           <profiles>
-            <profile id="0ba28566-096d-51c4-f00c-787eab3c22dd" profileTypeId="4d61676963205374616e6461726423232344415441232323" name="Rampager's Standard" hidden="false" book="BRB" page="503">
+            <profile id="0ba28566-096d-51c4-f00c-787eab3c22dd" profileTypeId="4d61676963205374616e6461726423232344415441232323" name="Rampager&apos;s Standard" hidden="false" book="BRB" page="503">
               <characteristics>
                 <characteristic characteristicId="4d61676963616c20456d696e6174696f6e23232344415441232323" name="Magical Emination" value="Can re-roll charge distance dice."/>
               </characteristics>
@@ -4840,7 +4816,7 @@
           <profiles>
             <profile id="953cef45-af41-6664-c944-d1e3a8799797" profileTypeId="4d61676963205374616e6461726423232344415441232323" name="Banner of the Hidden Dead (FAQed)" hidden="false" book="AB" page="63">
               <characteristics>
-                <characteristic characteristicId="4d61676963616c20456d696e6174696f6e23232344415441232323" name="Magical Emination" value="Nominate one of your Infantry, Cavalry or chariot units not greater then 175 points. That unit gains Entombed Beneath the Sands (AB-29) rule. marker needs to be within 12&quot; of the banner. If banner bearer is destroyed then the unit is as well if it's still hidden. In addition every unit with Entombed Beneath the Earth rule attampts to emerge within 12&quot; of the banner can re-roll the scatter and artillery dice."/>
+                <characteristic characteristicId="4d61676963616c20456d696e6174696f6e23232344415441232323" name="Magical Emination" value="Nominate one of your Infantry, Cavalry or chariot units not greater then 175 points. That unit gains Entombed Beneath the Sands (AB-29) rule. marker needs to be within 12&quot; of the banner. If banner bearer is destroyed then the unit is as well if it&apos;s still hidden. In addition every unit with Entombed Beneath the Earth rule attampts to emerge within 12&quot; of the banner can re-roll the scatter and artillery dice."/>
               </characteristics>
               <modifiers/>
             </profile>
@@ -4855,7 +4831,7 @@
           <profiles>
             <profile id="420a99c3-77b8-07d3-3a05-78260e0e3bb2" profileTypeId="4d61676963205374616e6461726423232344415441232323" name="Standard of the Undying Legion" hidden="false" book="AB" page="63">
               <characteristics>
-                <characteristic characteristicId="4d61676963616c20456d696e6174696f6e23232344415441232323" name="Magical Emination" value="Bound Spell (power level 5). This banner contains an augment spell that can only be cast on the bearer's unit. If succesfully cast recover D6+2 Wounds' worth of models as described in Resurrecting Fallen Warriors (AB-28)"/>
+                <characteristic characteristicId="4d61676963616c20456d696e6174696f6e23232344415441232323" name="Magical Emination" value="Bound Spell (power level 5). This banner contains an augment spell that can only be cast on the bearer&apos;s unit. If succesfully cast recover D6+2 Wounds&apos; worth of models as described in Resurrecting Fallen Warriors (AB-28)"/>
               </characteristics>
               <modifiers/>
             </profile>
@@ -4912,7 +4888,7 @@
             <profile id="56b5ce37-c0f8-703d-a8ea-4c4916d6599f" profileTypeId="576561706f6e23232344415441232323" name="Sword of Might" hidden="false" book="BRB" page="501">
               <characteristics>
                 <characteristic characteristicId="52616e676523232344415441232323" name="Range" value="Combat"/>
-                <characteristic characteristicId="537472656e67746823232344415441232323" name="Strength" value="'+1"/>
+                <characteristic characteristicId="537472656e67746823232344415441232323" name="Strength" value="&apos;+1"/>
                 <characteristic characteristicId="5370656369616c2052756c657323232344415441232323" name="Special Rules"/>
               </characteristics>
               <modifiers/>
@@ -5082,7 +5058,7 @@
             <profile id="4eb92788-c227-4f78-e7ef-d321730846bb" profileTypeId="576561706f6e23232344415441232323" name="Sword of Anti-Heroes" hidden="false" book="BRB" page="501">
               <characteristics>
                 <characteristic characteristicId="52616e676523232344415441232323" name="Range" value="Combat"/>
-                <characteristic characteristicId="537472656e67746823232344415441232323" name="Strength" value="'+1*"/>
+                <characteristic characteristicId="537472656e67746823232344415441232323" name="Strength" value="&apos;+1*"/>
                 <characteristic characteristicId="5370656369616c2052756c657323232344415441232323" name="Special Rules" value="+1S and +1A for every enemy character in base contact."/>
               </characteristics>
               <modifiers/>
@@ -5090,17 +5066,17 @@
           </profiles>
           <links/>
         </entry>
-        <entry id="121c232e-bacd-0796-642d-ac2d90d08e13" name="BRB - Fencer's Blades" points="35.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+        <entry id="121c232e-bacd-0796-642d-ac2d90d08e13" name="BRB - Fencer&apos;s Blades" points="35.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
           <entries/>
           <entryGroups/>
           <modifiers/>
           <rules/>
           <profiles>
-            <profile id="5542e80d-4cea-6e8a-3c81-1fdbea4a6cab" profileTypeId="576561706f6e23232344415441232323" name="Fencer's Blades" hidden="false" book="BRB" page="501">
+            <profile id="5542e80d-4cea-6e8a-3c81-1fdbea4a6cab" profileTypeId="576561706f6e23232344415441232323" name="Fencer&apos;s Blades" hidden="false" book="BRB" page="501">
               <characteristics>
                 <characteristic characteristicId="52616e676523232344415441232323" name="Range" value="Combat"/>
                 <characteristic characteristicId="537472656e67746823232344415441232323" name="Strength" value="As user"/>
-                <characteristic characteristicId="5370656369616c2052756c657323232344415441232323" name="Special Rules" value="Paired Weapons (FAQ'ed)(BRB-501). WS 10."/>
+                <characteristic characteristicId="5370656369616c2052756c657323232344415441232323" name="Special Rules" value="Paired Weapons (FAQ&apos;ed)(BRB-501). WS 10."/>
               </characteristics>
               <modifiers/>
             </profile>
@@ -5133,7 +5109,7 @@
             <profile id="3d95b217-0792-8bf5-b955-0e18971abf9d" profileTypeId="576561706f6e23232344415441232323" name="Ogre Blade" hidden="false" book="BRB" page="501">
               <characteristics>
                 <characteristic characteristicId="52616e676523232344415441232323" name="Range" value="Combat"/>
-                <characteristic characteristicId="537472656e67746823232344415441232323" name="Strength" value="'+2"/>
+                <characteristic characteristicId="537472656e67746823232344415441232323" name="Strength" value="&apos;+2"/>
                 <characteristic characteristicId="5370656369616c2052756c657323232344415441232323" name="Special Rules"/>
               </characteristics>
               <modifiers/>
@@ -5184,7 +5160,7 @@
             <profile id="938db574-aef2-67cb-3116-0ca58e7f7804" profileTypeId="576561706f6e23232344415441232323" name="Giant Blade" hidden="false" book="BRB" page="501">
               <characteristics>
                 <characteristic characteristicId="52616e676523232344415441232323" name="Range" value="Combat"/>
-                <characteristic characteristicId="537472656e67746823232344415441232323" name="Strength" value="'+3"/>
+                <characteristic characteristicId="537472656e67746823232344415441232323" name="Strength" value="&apos;+3"/>
                 <characteristic characteristicId="5370656369616c2052756c657323232344415441232323" name="Special Rules"/>
               </characteristics>
               <modifiers/>
@@ -5218,7 +5194,7 @@
             <profile id="72a0cc65-6efc-24d0-f1c4-a8d43d3081f4" profileTypeId="576561706f6e23232344415441232323" name="Destroyer of Eternities" hidden="false" book="AB" page="62">
               <characteristics>
                 <characteristic characteristicId="52616e676523232344415441232323" name="Range" value="Combat"/>
-                <characteristic characteristicId="537472656e67746823232344415441232323" name="Strength" value="'+2"/>
+                <characteristic characteristicId="537472656e67746823232344415441232323" name="Strength" value="&apos;+2"/>
                 <characteristic characteristicId="5370656369616c2052756c657323232344415441232323" name="Special Rules" value="Tomb King on foot only. Heroic Killing Blow (BRB-72). Can swap all his attacks for a Sweeping Attack for automatic hit on all enemy models in base contact."/>
               </characteristics>
               <modifiers/>
@@ -5420,344 +5396,240 @@
     </entryGroup>
   </sharedEntryGroups>
   <sharedRules>
-    <rule id="4f17b550-4924-0528-3124-3ccb504442d3" name="'And the Tomb Kings Rode to War...'" hidden="false" book="AB" page="38">
-      <description>.</description>
+    <rule id="4f17b550-4924-0528-3124-3ccb504442d3" name="&apos;And the Tomb Kings Rode to War...&apos;" hidden="false" book="AB" page="38">
+      <description>Tomb Kings characters on chariots may join a Chariot unit. They can remain in the unit if their mount is destroyed, but once they leave are unable to rejoin.</description>
       <modifiers/>
     </rule>
-    <rule id="af5a2566-b49d-42cf-e1b3-143a85c74a0e" name="Always Strikes First (FAQ'ed)" hidden="false" book="BRB" page="66">
-      <description>ERRATA
-Change “[...]re-roll failed misses[...]” to “[...]re-roll
-misses[...]” in the first sentence of the third paragraph.</description>
+    <rule id="af5a2566-b49d-42cf-e1b3-143a85c74a0e" name="Always Strikes First" hidden="false" book="BRB" page="66">
+      <description>Always strikes before normal initiative step, but after Impact Hits. Cancels out when the model also has Always Strikes Last. Rerolls failed to Hit rolls if the models Initiative is higher than targets Initiative.</description>
       <modifiers/>
     </rule>
     <rule id="e4f531d2-d570-3a29-3d70-90004ae5aebe" name="Always Strikes Last" hidden="false" book="BRB" page="66">
-      <description>.</description>
+      <description>Always strikes after normal Initiative step.</description>
       <modifiers/>
     </rule>
-    <rule id="abb8df4c-142e-2f22-6b23-d69097b95c5b" name="Ambushers (FAQ'ed)" hidden="false" book="BRB" page="79">
-      <description>ERRATA:
-Change “[...]start of the turn[...]” to “[...]start of his
-turn[...]” in the second paragraph</description>
+    <rule id="abb8df4c-142e-2f22-6b23-d69097b95c5b" name="Ambushers" hidden="false" book="BRB" page="79">
+      <description>Unit is not deployed before battle. Player must throw a D6 at the beginning of each his turns for each ambushing unit. On a 3+ they arrive in the Remaining Moves sub-phase. On 1-2 try again next turn. Units that do not arrive until the end of the battle count as destroyed. Ambushing units may arrive at any point on any board edge and move with the rules for Reinforcements.</description>
       <modifiers/>
     </rule>
     <rule id="124e730b-0999-1b81-7113-09227fe16326" name="Animated Construct" hidden="false" book="AB" page="28">
-      <description>.</description>
+      <description>Armour save 5+. Unit suffers one less Wound from Unstable or due to the Hierophant&apos;s death. Stacks with Tomb Kings Battle Standard .</description>
       <modifiers/>
     </rule>
     <rule id="6427f190-f7d8-8413-df5e-b3d14ad2fe8c" name="Armour Piercing" hidden="false" book="BRB" page="67">
-      <description>.</description>
+      <description>-1 to Armour saves against attacks with this special rule.</description>
       <modifiers/>
     </rule>
     <rule id="5b1990fd-d4ac-fec5-e015-753724d1134c" name="Arrows of Asaph" hidden="false" book="AB" page="28">
-      <description>.</description>
+      <description>Ignore bonuses or penalties to hit when shooting. Regardless of the source.</description>
       <modifiers/>
     </rule>
     <rule id="81c4783f-b742-0c3b-e7f9-089181ce3c19" name="Breath Weapons" hidden="false" book="BRB" page="67">
-      <description>.</description>
+      <description>Once per game only. Models with multiple breat weapons may only use one per turn. SHOOTING ATTACK: During the shooting phase (regardless if the model reformed or marched), place the breath weapon template such it lies completely in the front arch of the model, the narrow end must touche the creature&apos;s mouth, and no friendly models or models in close combat lie below the template. All models below the template are automatically hit by the breath weapon. CLOSE COMBAT ATTACK: The model makes an additional attack against a unit in base contact at it&apos;s Initiative step causing 2D6 hits.</description>
       <modifiers/>
     </rule>
     <rule id="dc2c521f-a019-67bc-3536-f658d57b8ff2" name="Chariot Legions" hidden="false" book="AB" page="38">
-      <description>.</description>
+      <description>Chariot units need three models for rank bonus. Impact Hits add the rank bonus to their Strength.</description>
       <modifiers/>
     </rule>
     <rule id="0242c06b-1205-fe05-0a76-4f2173b56e55" name="Devastating Charge" hidden="false" book="BRB" page="68">
-      <description>.</description>
+      <description>Models gain +1 Attack on charge.</description>
       <modifiers/>
     </rule>
-    <rule id="1f1e7b48-e530-8836-eb39-623d64b6f348" name="Entombed Beneath the Sands (FAQ'ed)" hidden="false" book="AB" page="29">
-      <description>AMENDMENTS
-Page 29 – Army Special Rules, Entombed Beneath the Sands
-Add “A unit with the Entombed Beneath the Sands special
-rule may choose to deploy normally along with the rest of the
-army if the owning player wishes. In this case, the owning
-player must clearly state this to their opponent before either
-player begins deploying their army.</description>
-      <modifiers/>
-    </rule>
-    <rule id="555ba246-857d-695f-74ae-32f431c0214f" name="Ethereal" hidden="false" book="BRB" page="68">
-      <description>.</description>
-      <modifiers/>
-    </rule>
-    <rule id="87ca68b8-b7e5-de76-ae30-992cae97077a" name="Extra Attack (FAQ'ed)" hidden="false" book="BRB" page="69">
-      <description>ERRATA:
-Add “Unlike most special rules, the effects of multiple Extra
-Attack special rules are cumulative.”</description>
+    <rule id="1f1e7b48-e530-8836-eb39-623d64b6f348" name="Entombed Beneath the Sands" hidden="false" book="AB" page="29">
+      <description>Ambusher. Place small marker in Remaining Moves sub-phase, not in impassable terrain or within 1&quot; of a unit. Scatter by Artillery dice. When final position is under a unit or impassable terrain, move within 1&quot; of closest edge. Place unit in a legal formation such that one model touches the marker. Only characters with this special rule can be deployed within buried units. If missfire or off table, see table:
+1-2: Destroyed
+3-4: Try again next turn.
+5-6: Enter from randomly determined board edge like reinforcement.
+Unit may be deployed normally, when stated before either player begins depolyment.</description>
       <modifiers/>
     </rule>
     <rule id="de92e476-d700-2c5a-09e4-8b09fed01c24" name="Fast Cavalry" hidden="false" book="BRB" page="68">
-      <description>.</description>
+      <description>Vanguard. Free Reforms during Movement. March and Shoot (except weapons with Move or Shoot). When fleeing from a charge and regrouping in the next turn, the unit reforms, then moves and shoots normally. Looses all Fast Cavalry when joined by a character withouth the special rule.</description>
       <modifiers/>
     </rule>
     <rule id="625ff1b5-5ad6-ce26-3349-55cdf4b7e0c0" name="Fear" hidden="false" book="BRB" page="69">
-      <description>.</description>
+      <description>Enemy units must take a LD test at the beginning of each close combat phase. If failed, their WS is reduced to 1 for the remainder of the pase. Models that cause Fear are immune.</description>
       <modifiers/>
     </rule>
-    <rule id="7802403b-3470-fd82-65e8-d3ffcc18b12c" name="Fight in Extra Ranks (FAQ'ed)" hidden="false" book="BRB" page="69">
-      <description>ERRATA
-Add “Unlike most special rules, the effects of multiple Fight
-In Extra Ranks special rules are cumulative.”</description>
+    <rule id="7802403b-3470-fd82-65e8-d3ffcc18b12c" name="Fight in Extra Ranks" hidden="false" book="BRB" page="69">
+      <description>Unit may make supporting attacks from an additional rank.</description>
       <modifiers/>
     </rule>
     <rule id="6882b007-8522-8f7c-3828-430904331beb" name="Flaming Attacks" hidden="false" book="BRB" page="69">
-      <description>.</description>
+      <description>Cause Fear against Beast, Cavalry and Chariots. Reroll hits to Wound against units in Buildings.</description>
       <modifiers/>
     </rule>
     <rule id="66506601-bad1-0e69-5149-6873cc620b30" name="Flammable" hidden="false" book="BRB" page="69">
-      <description>.</description>
+      <description>Double unsaved Wounds caused by Flaming Attacks.</description>
       <modifiers/>
     </rule>
     <rule id="f74e5eba-4463-61f0-9c26-2cc96fd40fff" name="Fly" hidden="false" book="BRB" page="70">
-      <description>.</description>
+      <description>Fast Movement. Skirmishers.
+MOVING FLIERS: May make a 10&quot; fly movement over terrain and units. May also move normally on ground using Movement profile value. Use 10&quot; movement for charges. May not sop movement in impassable terrain.
+MARCHING FLIERS: May make a march movement of 20&quot;.
+FLEEING AND PURSUING: Flyers must flee and pursue on the ground.
+FLYING CAVALRY: Also use rules for Fast Cavalry.</description>
       <modifiers/>
     </rule>
     <rule id="06f672e2-e7c6-aff9-85c4-a8d19f4cde09" name="Frenzy" hidden="false" book="BRB" page="70">
-      <description>.</description>
+      <description>+1 Attack. Immune to Psychology. Must charge nearest unit if it does not pass a LD test. Must always pursue or overrun. When a close combat is lost, Frenzy is lost.</description>
       <modifiers/>
     </rule>
     <rule id="29a4896f-0e8f-e934-59a9-41f02a601ded" name="Hatred" hidden="false" book="BRB" page="71">
-      <description>.</description>
+      <description>Reroll failed to Hit rolls in the first round of Close Combat.</description>
       <modifiers/>
     </rule>
     <rule id="ddec54b1-4744-b60c-284f-ea9f8ade47c3" name="Hatred (Vampire Counts)" hidden="false" book="BRB" page="71">
-      <description>.</description>
+      <description>Reroll failed to Hit rolls in the first round of Close Combat against models from the Vampire Counts Army Book.</description>
       <modifiers/>
     </rule>
     <rule id="2b327871-42f6-6196-2995-bba29a231bb4" name="Heroic Killing Blow" hidden="false" book="BRB" page="72">
-      <description>.</description>
+      <description>Rolls to Wound kill automatically on a 6 with no armour or regeneration saves allowed.</description>
       <modifiers/>
     </rule>
     <rule id="b2337262-488f-5dbc-7ef0-e31e19a3cf0f" name="Hover" hidden="false" book="BRB" page="71">
-      <description>.</description>
-      <modifiers/>
-    </rule>
-    <rule id="16039843-c3b3-eacf-c05f-d399f71e5507" name="Ignores Cover" hidden="false" book="BRB" page="71">
-      <description>.</description>
+      <description>Fly. Cannot march.</description>
       <modifiers/>
     </rule>
     <rule id="847051ef-2a3c-b656-4098-b9f3c6f786d5" name="Immune to Psychology" hidden="false" book="BRB" page="71">
-      <description>.</description>
+      <description>Unit automatically passes Panic, Fear and Terror tests. May not flee when charged.</description>
       <modifiers/>
     </rule>
-    <rule id="40c34250-2803-34e6-2ae5-4d713d4c912d" name="Impact Hits (D6) (FAQ'ed)" hidden="false" book="BRB" page="71">
-      <description>ERRATA:
-Change “[...]this rule has no effect.” to “[...]no Impact Hits
-are inflicted.”
-
-Add the following sentence to the end of the third paragraph:
-‘“Look Out Sir!” rolls cannot be taken against Impact Hits.’</description>
+    <rule id="40c34250-2803-34e6-2ae5-4d713d4c912d" name="Impact Hits (D6)" hidden="false" book="BRB" page="71">
+      <description>Are caused on charge upon unit in base contact, before challenges are issued.
+&quot;Look Out Sir!&quot; rolls cannot be taken against Impact Hits.</description>
       <modifiers/>
     </rule>
     <rule id="1bc0c05a-c4cc-eaa5-6ce8-fe78416a2f62" name="Killing Blow" hidden="false" book="BRB" page="72">
-      <description>.</description>
+      <description>Rolls to Wound kill Infantry, Cavalry, Mounts automatically on a 6 with no armour or regeneration saves allowed.</description>
       <modifiers/>
     </rule>
     <rule id="44d0e3d2-17ad-6d84-b2b6-b2be8a5d0b5d" name="Large Target" hidden="false" book="BRB" page="72">
-      <description>.</description>
+      <description>Does not profit from cover.</description>
       <modifiers/>
     </rule>
     <rule id="cc9a29e1-a2be-16cb-c03f-f9d930d58618" name="Loremaster (*)" hidden="false" book="BRB" page="72">
-      <description>.</description>
+      <description>Wizard knows all spell from specified Lore.</description>
       <modifiers/>
     </rule>
     <rule id="3e23baa5-9f13-8205-b460-ad821b20a148" name="Magic Resistance (*)" hidden="false" book="BRB" page="72">
-      <description>.</description>
-      <modifiers/>
-    </rule>
-    <rule id="91d3e08d-0f7e-c998-27c4-5f238a3cff2f" name="Monster and Handlers" hidden="false" book="BRB" page="73">
-      <description>.</description>
-      <modifiers/>
-    </rule>
-    <rule id="2382cc5b-9472-ded2-d2ed-a18e6dcc57b5" name="Move or Fire" hidden="false" book="BRB" page="73">
-      <description>.</description>
+      <description>Improves or gains Ward Save against magical attacks by (1-3).</description>
       <modifiers/>
     </rule>
     <rule id="85a28f28-237d-34d7-cc84-feedc93af916" name="Multiple Shots" hidden="false" book="BRB" page="73">
-      <description>.</description>
+      <description>Shoot multiple times. Add -1 to Hit.</description>
       <modifiers/>
     </rule>
     <rule id="75f29c20-d1b6-d891-9c9b-65df7bd9488c" name="Multiple Wounds" hidden="false" book="BRB" page="73">
-      <description>.</description>
+      <description>Unsaved Wounds cause multiple Wound losses.</description>
       <modifiers/>
     </rule>
     <rule id="e017be51-357a-de8d-8b91-4f1c0b95897d" name="My Will Be Done" hidden="false" book="AB" page="30">
-      <description>.</description>
+      <description>Nehekharan Undead accompanied use the unmodified Weapon Skill of this character. Has no effect on other characters or mounts. Immediatly ends upon the character&apos;s death.</description>
       <modifiers/>
     </rule>
     <rule id="651f855b-ceb4-95ec-b733-d57f9f662285" name="Nehekharan Undead" hidden="false" book="AB" page="28">
-      <description>.</description>
+      <description>Unbreakable, Unstable, Fear. Can never march. When charged can only elect to hold.</description>
       <modifiers/>
     </rule>
     <rule id="8a6d52bd-9b49-4737-9780-2914f581915c" name="Poisoned Attacks" hidden="false" book="BRB" page="73">
-      <description>.</description>
-      <modifiers/>
-    </rule>
-    <rule id="a1721dfe-dbbd-1d6b-b80a-9be4132fcf49" name="Quick to Fire" hidden="false" book="BRB" page="73">
-      <description>.</description>
-      <modifiers/>
-    </rule>
-    <rule id="f581f951-1f8f-3d0c-2d10-07024663801c" name="Random Attacks" hidden="false" book="BRB" page="74">
-      <description>.</description>
-      <modifiers/>
-    </rule>
-    <rule id="95f66288-aad4-3001-ebe9-aa26117d5238" name="Random Movement (FAQ'ed)" hidden="false" book="BRB" page="74">
-      <description>ERRATA:
-Add “If a model has the Random Movement and Swiftstride
-special rules (a chariot with Random Movement, for example),
-then the Swiftstride special rule is not used.” to the end of the
-first paragraph.</description>
+      <description>Rolls to Hit wound automatically on a 6.</description>
       <modifiers/>
     </rule>
     <rule id="c4cd38bf-34d3-4808-c7f0-4abd591b3024" name="Regeneration" hidden="false" book="BRB" page="74">
-      <description>.</description>
-      <modifiers/>
-    </rule>
-    <rule id="b95a0850-58a7-fb85-8ef8-cf950a79291d" name="Requires Two Hands" hidden="false" book="BRB" page="75">
-      <description>.</description>
-      <modifiers/>
-    </rule>
-    <rule id="480d43bd-3ada-ff4d-aad3-698e96cbb69f" name="Scaly Skin (*)" hidden="false" book="BRB" page="75">
-      <description>.</description>
+      <description>Can be taken as a ward save except when caused by Flaming Attacks or a Wound was taken from a Flaming Attack earlier in the phase. (4+ if not specified otherwise)</description>
       <modifiers/>
     </rule>
     <rule id="24a9503d-5e3e-2d5e-2006-23ff12bba3a2" name="Scouts" hidden="false" book="BRB" page="79">
-      <description>.</description>
+      <description>Scouts are deployed afer all other non-Scout units. May be placed anywhere on the battlefield amore than 12&quot; away from enemy units. Scouted units cannot charge if the player has first turn. Roll of which player may deploy his Scouts first.</description>
       <modifiers/>
     </rule>
     <rule id="32dc34af-9ea7-4684-23ad-3b1d1400b452" name="Scythes" hidden="false" book="BRB" page="86">
-      <description>.</description>
+      <description>+1 Impact hit from Chariot.</description>
       <modifiers/>
     </rule>
-    <rule id="963f2751-6502-38fa-2970-a2c40916d1a2" name="Skirmishers (FAQ'ed)" hidden="false" book="BRB" page="77">
-      <description>ERRATA
-Free Reform.
-Change “[...]move, provided[...]” to “[...]move, even if it
-marches, provided[...]”. Change “[...]double its Move value.”
-to “[...]double its Movement value.”
-
-Light Troops.
-Change “[...]zero ranks[...]” to “[...]zero ranks in
-combat[...]”.</description>
-      <modifiers/>
-    </rule>
-    <rule id="519cc67d-b104-c4e8-eb23-fb89e4dab0d8" name="Slow to Fire" hidden="false" book="BRB" page="75">
-      <description>.</description>
-      <modifiers/>
-    </rule>
-    <rule id="6538de16-1231-4648-caf5-037490841add" name="Sniper (FAQ'ed)" hidden="false" book="BRB" page="75">
-      <description>ERRATA:
-Change “A model making a[...]” to “unless making a Stand
-and Shoot charge reaction, a model making a[...]” at the start
-of the third paragraph.</description>
+    <rule id="963f2751-6502-38fa-2970-a2c40916d1a2" name="Skirmishers" hidden="false" book="BRB" page="77">
+      <description>LOOSE FORMATION: Place models in a half inch distance to each other in a legal formation. CHARGES: Move the Skrimishers in base contact with each other when charing or being charged. Use one of the middlemost models in the first row as the anchor. FREE REFORMS: Unit may reform freely during movement, but no model may move more than it&apos;s march distance. MARCH AND SHOOT: Unless weapon has Move or Shoot. Apply modifier for movement. LIGHT TROOPS: -1 Modifier for shooting attacks against the unit. Does not gain rank bonus in close combat. CHARACTERS: Characters that join the unit gain the Skirmishers special rule while they remain in the unit. Mounted characters may not join Skirmishers.</description>
       <modifiers/>
     </rule>
     <rule id="eb8e9d76-127b-9bb6-89ed-5baccc059ecc" name="Stomp" hidden="false" book="BRB" page="76">
-      <description>.</description>
+      <description>Models causes an additional Hit with Always Strikes Last at profile strength against Infantry, Beasts and Swarms.</description>
       <modifiers/>
     </rule>
     <rule id="91edde3b-d20e-0a2b-9eac-e00e65cb953a" name="Stone Shaper" hidden="false" book="AB" page="33">
-      <description>.</description>
+      <description>Any units of Animated Constucts within 12&quot; of the model gain Regeneration (6+).</description>
       <modifiers/>
     </rule>
     <rule id="1b0dba60-d5e0-ca3d-836b-db23e363a17a" name="Strider" hidden="false" book="BRB" page="76">
-      <description>.</description>
+      <description>Ignores dangerous terrain.</description>
       <modifiers/>
     </rule>
     <rule id="acd900e8-6f08-de24-eda4-ee45b9184a08" name="Stubborn" hidden="false" book="BRB" page="76">
-      <description>.</description>
+      <description>Always Steadfast. Transferred to unit if a character with this special rule joins.</description>
       <modifiers/>
     </rule>
     <rule id="2884d065-68e3-88c0-9f1e-83a6a572cb74" name="Stupidity" hidden="false" book="BRB" page="76">
-      <description>.</description>
+      <description>Immune to Psychology. Outside of close combat, the model must take a LD test at the beginnig of the turn. If failed, the unit moves D6 inch forward then cannot shoot, cast spells or channel power dice this turn.</description>
       <modifiers/>
     </rule>
     <rule id="94d0055e-0547-fb3b-d933-05b3aaef8b1f" name="Swiftstride" hidden="false" book="BRB" page="76">
-      <description>.</description>
+      <description>Use 3D6 for charging, pursuing, fleeing and overrunning.</description>
       <modifiers/>
     </rule>
     <rule id="764ec464-0ac5-7d4c-33e3-14f66ce18248" name="Sworn Bodyguard" hidden="false" book="AB" page="32">
-      <description>.</description>
+      <description>If If a TK or TP is present, must nominate one to protect. A character may not be protected by multiple Bodyguards. When protected character is in same unit and suffers a Wound (bevore saves), roll a D6, on 2+ the Wound is re-allocated to the Herald. One wound can be re-allocated per Tomb Herald per Phase. Does not work for Wounds caused in a challenge.</description>
       <modifiers/>
     </rule>
     <rule id="0d6cd076-b08e-7e6a-978a-e15a7f9ba463" name="Terror" hidden="false" book="BRB" page="78">
-      <description>.</description>
+      <description>Cause Fear, also against models which cause Fear, but not Terror. When charging, target unit must immediately take panic test before choosing a charge reaction.</description>
       <modifiers/>
     </rule>
     <rule id="57a86508-53fe-1293-1220-04153e47b8db" name="The Curse" hidden="false" book="AB" page="30">
-      <description>.</description>
+      <description>D6 S5 (King) or D6 S4 (Prince) hits are inflicted on the unit or challenger that is responsible for the character&apos;s death. Distributed as shooting attacks. If multiple units are responsible (Unstable) then all units are affected.</description>
       <modifiers/>
     </rule>
     <rule id="9241794e-9185-07ba-450e-5f4b3d2058e6" name="The Hierophant" hidden="false" book="AB" page="28">
-      <description>.</description>
+      <description>Army must include at least one Nehekharan Undead Wizard. Must always be one of the wizards with the highest wizard level. Must chose the Lore of Nehekhara.
+All models in the same unit gain Regeneration (6+).
+If destoyed, at the end of the phase and at the start of each friendly turn thereafter, all friendly Nehekharan Undead units on the battlefield must take a LD test, suffering wounds for each point the test is failed. No saves of any kind allowed.</description>
       <modifiers/>
     </rule>
     <rule id="bdb0fa5e-2a33-4794-e499-19beeb70491c" name="Thunderstomp" hidden="false" book="BRB" page="76">
-      <description>.</description>
+      <description>Models causes additional D6 Hits with Always Strikes Last at profile strength against Infantry, Beasts and Swarms.</description>
       <modifiers/>
     </rule>
     <rule id="c05f14c0-e274-0a45-b320-68e0fbb07f37" name="Unbreakable" hidden="false" book="BRB" page="78">
-      <description>.</description>
+      <description>Immune to Psychology. Never breaks from Combat. Characters which are not unbreakable may not join unbreakable units.</description>
       <modifiers/>
     </rule>
     <rule id="6461182e-0ce9-c71a-bcaa-6d518b47bb43" name="Unstable" hidden="false" book="BRB" page="78">
-      <description>.</description>
+      <description>Every unit loses additional Wounds for every point a combat is lost, with no saves allowed. Only unstable charcters may join unstable units. First the unit is affected, then distribute wounds as evenly as possible among characters.</description>
       <modifiers/>
     </rule>
-    <rule id="9de28ca6-6c1a-beb5-088b-eabf26972b20" name="Vanguard (FAQ'ed)" hidden="false" book="BRB" page="79">
-      <description>ERRATA:
-Change “[...]make a 12" move[...]” to “[...]make a move of
-up to 12"[...]”.</description>
+    <rule id="9de28ca6-6c1a-beb5-088b-eabf26972b20" name="Vanguard" hidden="false" book="BRB" page="79">
+      <description>After deployment (including Scouts) this unit may make a 12&quot; move before the first turn. Unit must remain more than 12&quot; from enemy units. If both players have Vanguarding models, roll off who goes first. The player with the first turn may not charge with Vanguarded units.</description>
       <modifiers/>
     </rule>
     <rule id="c666436c-a2be-a416-7e1d-14309c854ac3" name="Volley Fire" hidden="false" book="BRB" page="78">
-      <description>.</description>
+      <description>Half the models per rank (round up) after the second may shoot.</description>
       <modifiers/>
     </rule>
     <rule id="6b377ffb-d0fa-6d5d-238f-83937180edbc" name="Ward Save (*)" hidden="false" book="BRB" page="44">
-      <description>.</description>
+      <description>May be taken after Armour save. Always fails on roll of a 1.</description>
       <modifiers/>
     </rule>
     <rule id="dfbf8ce0-9f14-5644-d05d-d0a9e10a233f" name="Wrath of the Creator" hidden="false" book="AB" page="33">
-      <description>.</description>
+      <description>The unit of this character gains hatred. Unit immediately loses the rule when the character leaves or is slain.</description>
       <modifiers/>
     </rule>
   </sharedRules>
   <sharedProfiles>
-    <profile id="079f3614-6f34-b17a-cf32-24fd15c33265" profileTypeId="41726d6f757223232344415441232323" name="Barding" hidden="false" book="BRB" page="83">
-      <characteristics>
-        <characteristic characteristicId="536176696e67205468726f77206d6f64696669657223232344415441232323" name="Saving Throw modifier" value="-1"/>
-        <characteristic characteristicId="5370656369616c2052756c657323232344415441232323" name="Special Rules" value="-1M"/>
-      </characteristics>
-      <modifiers/>
-    </profile>
     <profile id="92b19831-ae1f-0325-e8b4-4e9a109cb885" profileTypeId="576561706f6e23232344415441232323" name="Bow" hidden="false" book="BRB" page="90">
       <characteristics>
         <characteristic characteristicId="52616e676523232344415441232323" name="Range" value="24&quot;"/>
         <characteristic characteristicId="537472656e67746823232344415441232323" name="Strength" value="3"/>
         <characteristic characteristicId="5370656369616c2052756c657323232344415441232323" name="Special Rules" value="Volley Fire (BRB-78)"/>
-      </characteristics>
-      <modifiers/>
-    </profile>
-    <profile id="7a54e952-1dc0-df21-4ecf-3ccaec18e70a" profileTypeId="576561706f6e23232344415441232323" name="Brace of Pistols (Combat) (FAQ'ed)" hidden="false" book="BRB" page="91">
-      <characteristics>
-        <characteristic characteristicId="52616e676523232344415441232323" name="Range" value="Combat"/>
-        <characteristic characteristicId="537472656e67746823232344415441232323" name="Strength" value="As user"/>
-        <characteristic characteristicId="5370656369616c2052756c657323232344415441232323" name="Special Rules" value="Extra Attack (BRB-69), Requires Two Hands (BRB-75)"/>
-      </characteristics>
-      <modifiers/>
-    </profile>
-    <profile id="87e36836-8c0e-07c4-e3a6-23e367a827ec" profileTypeId="576561706f6e23232344415441232323" name="Brace of Pistols (Shooting) (FAQ'ed)" hidden="false" book="BRB" page="91">
-      <characteristics>
-        <characteristic characteristicId="52616e676523232344415441232323" name="Range" value="12&quot;"/>
-        <characteristic characteristicId="537472656e67746823232344415441232323" name="Strength" value="4"/>
-        <characteristic characteristicId="5370656369616c2052756c657323232344415441232323" name="Special Rules" value="Armour Piercing (BRB-67), Multiple Shots (4) (BRB-73), Quick to Fire (BRB-73), Requires Two Hands (BRB-75)"/>
-      </characteristics>
-      <modifiers/>
-    </profile>
-    <profile id="e5633756-1e00-2f4e-2beb-4ae7b78d60f7" profileTypeId="576561706f6e23232344415441232323" name="Crossbow" hidden="false" book="BRB" page="90">
-      <characteristics>
-        <characteristic characteristicId="52616e676523232344415441232323" name="Range" value="30&quot;"/>
-        <characteristic characteristicId="537472656e67746823232344415441232323" name="Strength" value="4"/>
-        <characteristic characteristicId="5370656369616c2052756c657323232344415441232323" name="Special Rules" value="Move or Fire (BRB-73)"/>
       </characteristics>
       <modifiers/>
     </profile>
@@ -5772,7 +5644,7 @@ up to 12"[...]”.</description>
     <profile id="3bbe1ff7-1a8a-ed02-af34-3db24165654a" profileTypeId="576561706f6e23232344415441232323" name="Great Weapon" hidden="false" book="BRB" page="90">
       <characteristics>
         <characteristic characteristicId="52616e676523232344415441232323" name="Range" value="Combat"/>
-        <characteristic characteristicId="537472656e67746823232344415441232323" name="Strength" value="'+2"/>
+        <characteristic characteristicId="537472656e67746823232344415441232323" name="Strength" value="&apos;+2"/>
         <characteristic characteristicId="5370656369616c2052756c657323232344415441232323" name="Special Rules" value="Requires Two Hands (BRB-75), Always Strikes Last (BRB-66)"/>
       </characteristics>
       <modifiers/>
@@ -5780,7 +5652,7 @@ up to 12"[...]”.</description>
     <profile id="c2d368eb-dfb7-8d8a-db98-0539c3b4e316" profileTypeId="576561706f6e23232344415441232323" name="Halberd" hidden="false" book="BRB" page="90">
       <characteristics>
         <characteristic characteristicId="52616e676523232344415441232323" name="Range" value="Combat"/>
-        <characteristic characteristicId="537472656e67746823232344415441232323" name="Strength" value="'+1"/>
+        <characteristic characteristicId="537472656e67746823232344415441232323" name="Strength" value="&apos;+1"/>
         <characteristic characteristicId="5370656369616c2052756c657323232344415441232323" name="Special Rules" value="Requires Two Hands (BRB-75)"/>
       </characteristics>
       <modifiers/>
@@ -5804,22 +5676,6 @@ up to 12"[...]”.</description>
     <profile id="f419f778-c5fa-e8c8-95a0-9b8302fb1128" profileTypeId="41726d6f757223232344415441232323" name="Heavy Armour" hidden="false" book="BRB" page="43">
       <characteristics>
         <characteristic characteristicId="536176696e67205468726f77206d6f64696669657223232344415441232323" name="Saving Throw modifier" value="5+"/>
-        <characteristic characteristicId="5370656369616c2052756c657323232344415441232323" name="Special Rules"/>
-      </characteristics>
-      <modifiers/>
-    </profile>
-    <profile id="5a072dfd-2377-2ef2-2604-fa9fdaf53e46" profileTypeId="576561706f6e23232344415441232323" name="Javelin" hidden="false" book="BRB" page="90">
-      <characteristics>
-        <characteristic characteristicId="52616e676523232344415441232323" name="Range" value="12&quot;"/>
-        <characteristic characteristicId="537472656e67746823232344415441232323" name="Strength" value="As user"/>
-        <characteristic characteristicId="5370656369616c2052756c657323232344415441232323" name="Special Rules" value="Quick to Fire (BRB-73)"/>
-      </characteristics>
-      <modifiers/>
-    </profile>
-    <profile id="86f83f1c-7745-3d6a-05b1-f5d97e40372f" profileTypeId="576561706f6e23232344415441232323" name="Lance (mounted models only)" hidden="false" book="BRB" page="90">
-      <characteristics>
-        <characteristic characteristicId="52616e676523232344415441232323" name="Range" value="Combat"/>
-        <characteristic characteristicId="537472656e67746823232344415441232323" name="Strength" value="+2 on the charge"/>
         <characteristic characteristicId="5370656369616c2052756c657323232344415441232323" name="Special Rules"/>
       </characteristics>
       <modifiers/>
@@ -5888,14 +5744,6 @@ up to 12"[...]”.</description>
       </characteristics>
       <modifiers/>
     </profile>
-    <profile id="3d60a35c-61cb-427a-f199-7e29cf490438" profileTypeId="576561706f6e23232344415441232323" name="Sling" hidden="false" book="BRB" page="91">
-      <characteristics>
-        <characteristic characteristicId="52616e676523232344415441232323" name="Range" value="18&quot;"/>
-        <characteristic characteristicId="537472656e67746823232344415441232323" name="Strength" value="3"/>
-        <characteristic characteristicId="5370656369616c2052756c657323232344415441232323" name="Special Rules" value="Multiple Shots (2) (BRB-73)"/>
-      </characteristics>
-      <modifiers/>
-    </profile>
     <profile id="8ca1f0b6-6b39-471d-38bd-154827aca8ff" profileTypeId="576561706f6e23232344415441232323" name="Spear (Foot)" hidden="false" book="AB" page="91">
       <characteristics>
         <characteristic characteristicId="52616e676523232344415441232323" name="Range" value="Combat"/>
@@ -5912,27 +5760,11 @@ up to 12"[...]”.</description>
       </characteristics>
       <modifiers/>
     </profile>
-    <profile id="37fe3464-b482-211f-533e-95a732e170f0" profileTypeId="576561706f6e23232344415441232323" name="Throwing Axes" hidden="false" book="BRB" page="91">
-      <characteristics>
-        <characteristic characteristicId="52616e676523232344415441232323" name="Range" value="6&quot;"/>
-        <characteristic characteristicId="537472656e67746823232344415441232323" name="Strength" value="'+1"/>
-        <characteristic characteristicId="5370656369616c2052756c657323232344415441232323" name="Special Rules" value="Quick to Fire (BRB-73)"/>
-      </characteristics>
-      <modifiers/>
-    </profile>
-    <profile id="ff203ec0-14a2-0fc9-9699-a09eb995f130" profileTypeId="576561706f6e23232344415441232323" name="Throwing Weapons" hidden="false" book="BRB" page="91">
-      <characteristics>
-        <characteristic characteristicId="52616e676523232344415441232323" name="Range" value="6&quot;"/>
-        <characteristic characteristicId="537472656e67746823232344415441232323" name="Strength" value="As user"/>
-        <characteristic characteristicId="5370656369616c2052756c657323232344415441232323" name="Special Rules" value="Quick to Fire (BRB-73)"/>
-      </characteristics>
-      <modifiers/>
-    </profile>
-    <profile id="6cc3e674-3f33-d789-c2aa-0e661ac03695" profileTypeId="576561706f6e23232344415441232323" name="Two/Additional Hand Weapons (Models on foot only) (FAQ'ed)" hidden="false" book="BRB" page="91">
+    <profile id="6cc3e674-3f33-d789-c2aa-0e661ac03695" profileTypeId="576561706f6e23232344415441232323" name="Two/Additional Hand Weapons (Models on foot only)" hidden="false" book="BRB" page="91">
       <characteristics>
         <characteristic characteristicId="52616e676523232344415441232323" name="Range" value="Combat"/>
         <characteristic characteristicId="537472656e67746823232344415441232323" name="Strength" value="As user"/>
-        <characteristic characteristicId="5370656369616c2052756c657323232344415441232323" name="Special Rules" value="Extra Attack (BRB-69), Requires Two Hands (BRB-75)(FAQ)"/>
+        <characteristic characteristicId="5370656369616c2052756c657323232344415441232323" name="Special Rules" value="Extra Attack, Requires Two Hands"/>
       </characteristics>
       <modifiers/>
     </profile>


### PR DESCRIPTION
**File:** Tomb Kings - 8thBRB_8thAB.cat

**Description:** Removed army category, limitations on special and rare choices are now doubled if the army points limit is >= 3000.
Added short description to most of the special rules. (some special character rules descriptions are still ".")
Chariot units no longer spam the crew of every chariot in a detailed list. Instead it now says e.g. 2x Charioteer each, 6x Chariot, 2x Skeletton Horse each.
Necrolith Colossus is now correctly limited to choose one weapon upgrade and not multiple ones.
